### PR TITLE
added line to skip unmapped BAM files so that if unaligned bam does not ...

### DIFF
--- a/decider-bwa-pancancer/lib/GNOS/SampleInformation.pm
+++ b/decider-bwa-pancancer/lib/GNOS/SampleInformation.pm
@@ -123,6 +123,8 @@ sub get {
             foreach my $attribute (@$analysis_attributes) {
                 $attributes{$attribute->{TAG}} = $attribute->{VALUE};
             }
+            next if ($attributes{workflow_output_bam_contents} eq 'unaligned');
+
             $total_lanes = $attributes{total_lanes};
             $aliquot_uuid = $attributes{aliquot_id};
 


### PR DESCRIPTION
...exist the decider, when scheduling, will be able to recognize that the alignment was not completed
